### PR TITLE
Hide cursor while stationary

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	SceneScanSkip       int
 	SmartScroll         bool
 	Bookmarks           []Bookmark
+	HideIdleCursor      bool
 }
 
 func (c *Config) Load(path string) error {
@@ -93,4 +94,5 @@ func (c *Config) Defaults() {
 	c.ImageDiffThres = 0.4
 	c.SceneScanSkip = 5
 	c.SmartScroll = true
+	c.HideIdleCursor = true
 }

--- a/gomics.glade
+++ b/gomics.glade
@@ -1151,6 +1151,20 @@ Author: Utkan Güngördü
                     <property name="position">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkCheckButton" id="HideIdleCursorCheckButton">
+                    <property name="label" translatable="yes">Hide the cursor while stationary</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="position">2</property>

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
+	"time"
 )
 
 type State struct {
@@ -44,6 +45,9 @@ type State struct {
 	UserHome           string
 	ConfigPath         string
 	ImageHash          map[int]imgdiff.Hash
+	CursorLastMoved    time.Time
+	CursorHidden       bool
+	CursorForceShown   bool
 }
 
 func (gui *GUI) SetStatus(msg string) {
@@ -78,6 +82,9 @@ func (gui *GUI) Close() {
 	gui.ImageR.Clear()
 	gui.State.PixbufL = nil
 	gui.State.PixbufR = nil
+	gui.State.CursorLastMoved = time.Now()
+	gui.State.CursorHidden = false
+	gui.State.CursorForceShown = false
 	gui.SetStatus("")
 	gui.MainWindow.SetTitle("Gomics")
 	gc()
@@ -414,6 +421,10 @@ func (gui *GUI) SetOneWide(oneWide bool) {
 
 func (gui *GUI) SetSmartScroll(smartScroll bool) {
 	gui.Config.SmartScroll = smartScroll
+}
+
+func (gui *GUI) SetHideIdleCursor(hideIdleCursor bool) {
+	gui.Config.HideIdleCursor = hideIdleCursor
 }
 
 func (gui *GUI) SetEmbeddedOrientation(embeddedOrientation bool) {


### PR DESCRIPTION
Hides the cursor after it has been idle over the viewport for period of time.
Currently works under X11, Wayland support in GTK 3.33.
https://gitlab.gnome.org/GNOME/mutter/issues/630