### PR TITLE
Fix GDK constant names changed in upstream

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -444,8 +444,8 @@ func (gui *GUI) initUI() {
 	gui.MainWindow.Connect("key-press-event", func(_ *gtk.Window, e *gdk.Event) {
 		ke := &gdk.EventKey{e}
 
-		shift := ke.State()&uint(gdk.GDK_SHIFT_MASK) != 0
-		ctrl := ke.State()&uint(gdk.GDK_CONTROL_MASK) != 0
+		shift := ke.State()&uint(gdk.SHIFT_MASK) != 0
+		ctrl := ke.State()&uint(gdk.CONTROL_MASK) != 0
 
 		switch ke.KeyVal() {
 		case gdk.KEY_Down:


### PR DESCRIPTION
The GDK prefix was removed from the constant names in https://github.com/gotk3/gotk3/commit/a5a4a1c0ef1baab4808581265f10a88467cec5ae#diff-769c9bf6f9bcb3d5ae48936fadae4b3f thereby causing the build to fail.